### PR TITLE
feat: retarget tutorial to Command Center dashboard (single path)

### DIFF
--- a/.github/ISSUE_TEMPLATE/progress-tracker.md
+++ b/.github/ISSUE_TEMPLATE/progress-tracker.md
@@ -14,7 +14,7 @@ assignees: ""
 - [ ] Step 5: Link Antigravity to `github-startup` (`docs/steps/05-link-antigravity.md`)
 - [ ] Step 6: Authorize GitHub Extension and Push (`docs/steps/06-authorize-github-extension-and-push.md`)
 - [ ] Step 7: Deploy `github-startup` to GitHub Pages (`docs/steps/07-deploy-temporary-pages.md`)
-- [ ] Step 8: Choose Your Project Path (`docs/steps/08-choose-project-path.md`)
+- [ ] Step 8: Build Your Command Center Dashboard (`docs/steps/08-choose-project-path.md`)
 
 ## Optional Addendums
 

--- a/README.md
+++ b/README.md
@@ -6,9 +6,17 @@ Goal: create one GitHub repository named `github-startup`, clone it locally, and
 
 No HTML, CSS, or development experience is required.
 
-After setup is complete, you can move to one of the build tracks:
-- Week 8 Personal Dashboard
-- Project #5 Research Dashboard
+After setup is complete, you turn the deployed page into a project-management
+dashboard based on your **AI+Design Studio Command Center** (Canvas: Project 2,
+Step 2). This is the beginnings, not Project 5.
+
+You are done when you can do all four of these - and do them again, at home,
+by yourself:
+
+1. Understand which coding tool you will use (Claude Code, Codex, or Antigravity).
+2. Know you can get that tool as a desktop app or use it inside VS Code.
+3. Connect it to GitHub.
+4. Publish a webpage via GitHub Pages.
 
 ---
 
@@ -20,7 +28,8 @@ By the end, you will have:
 - VS Code connected to your GitHub account
 - Antigravity pointed at that local folder
 - one commit pushed from VS Code as a setup check
-- a temporary GitHub Pages URL proving deployment works
+- a live GitHub Pages URL proving deployment works
+- a Command Center dashboard published at that URL (Step 8)
 - optional addendums for Codex, Claude Code, and GitHub CLI auth if needed
 
 ---
@@ -68,7 +77,7 @@ Before you begin Step 1, create your own copy of this tutorial repo so you can t
 - [ ] [Step 5: Link Antigravity to `github-startup`](docs/steps/05-link-antigravity.md)
 - [ ] [Step 6: Authorize GitHub Extension and Push](docs/steps/06-authorize-github-extension-and-push.md)
 - [ ] [Step 7: Deploy `github-startup` to GitHub Pages](docs/steps/07-deploy-temporary-pages.md)
-- [ ] [Step 8: Choose Your Project Path](docs/steps/08-choose-project-path.md)
+- [ ] [Step 8: Build Your Command Center Dashboard](docs/steps/08-choose-project-path.md)
 
 ## Optional Addendums
 
@@ -78,18 +87,17 @@ Before you begin Step 1, create your own copy of this tutorial repo so you can t
 
 ---
 
-## Project Paths After Setup
+## After Setup: Your Command Center Dashboard
 
-Once setup is complete, choose one:
+Once setup is complete, [Step 8](docs/steps/08-choose-project-path.md) walks
+you through it: using your AI coding tool, run the **Interview &#8594;
+Brainstorm &#8594; Plan &#8594; Code &#8594; Commit** loop to turn the
+deployed `index.html` into a dashboard based on your AI+Design Studio Command
+Center. Keep or trim the seven sections - all of them or a subset of what you
+built. Beginnings-level content is fine.
 
-- **Personal Dashboard**
-  - Repo: <https://github.com/sicxz/wk8-link-dashboard-assignment>
-  - Issues: <https://github.com/sicxz/wk8-link-dashboard-assignment/issues>
-- **Research Dashboard for Project 2**
-  - Repo: <https://github.com/sicxz/project5-research-dashboard-assignment>
-  - Issues: <https://github.com/sicxz/project5-research-dashboard-assignment/issues>
-
-Note: The Week 8 URL includes `link-dashboard` from earlier naming. In this tutorial we call it **Personal Dashboard**.
+Submit your live GitHub Pages URL on the **GitHub Starter Tutorial**
+assignment in Canvas.
 
 ---
 

--- a/docs/steps/07-deploy-temporary-pages.md
+++ b/docs/steps/07-deploy-temporary-pages.md
@@ -12,9 +12,10 @@ Deploy the included temporary `index.html` and confirm your deployment flow work
 6. Click **Save**.
 7. Wait a few minutes.
 8. Open the GitHub Pages URL.
-9. Confirm the page says this is a temporary deployment/setup demo.
+9. Confirm your page is live. (You will turn it into your Command Center
+   dashboard in Step 8.)
 
 ## Checklist
 - [ ] I enabled GitHub Pages for `github-startup`.
 - [ ] I opened the live URL.
-- [ ] I confirmed the temporary setup page is live.
+- [ ] I confirmed my page is live.

--- a/docs/steps/08-choose-project-path.md
+++ b/docs/steps/08-choose-project-path.md
@@ -1,24 +1,34 @@
-# Step 8: Choose Your Project Path
+# Step 8: Build Your Command Center Dashboard
 
 ## Goal
-After setup and deployment checks are complete, choose the project track you want to build.
+After setup and deployment checks are complete, turn the deployed page into a
+project-management dashboard based on your **AI+Design Studio Command Center**
+(Canvas: Project 2, Step 2).
+
+You are not building Project 5. This is the beginnings - rough and
+brainstormed is fine. The point is the workflow.
 
 ## Instructions
-1. Choose one project path below.
-2. Open its issues and complete them in order.
-3. Build in your own project repository (not in this tutorial repo).
-
-Project paths:
-- **Week 8: Personal Dashboard**
-  - Repo: <https://github.com/sicxz/wk8-link-dashboard-assignment>
-  - Issues: <https://github.com/sicxz/wk8-link-dashboard-assignment/issues>
-- **Project #5: Research Dashboard for Project 2**
-  - Repo: <https://github.com/sicxz/project5-research-dashboard-assignment>
-  - Issues: <https://github.com/sicxz/project5-research-dashboard-assignment/issues>
-
-Note: Week 8 repo URL includes `link-dashboard` from earlier naming. In this tutorial we call it **Personal Dashboard**.
+1. Open `index.html` in your `github-startup` repo. It is already scaffolded
+   with the Command Center sections.
+2. Using your AI coding tool (Claude Code, Codex, or Antigravity), run the
+   loop: **Interview &#8594; Brainstorm &#8594; Plan &#8594; Code &#8594; Commit**.
+   Let the tool write a plan you review *before* it edits code.
+3. Replace the placeholder text with your real Command Center content.
+   **Keep or trim:** include all seven sections or only the ones you built.
+   - Project Identity Card
+   - Inquiry Brief (research question)
+   - Source Starter List
+   - Project Brief / Weekly Roadmap (Weeks 5-11)
+   - Prompt Log
+   - Experiment Log
+   - Links / Workspace Board
+4. Commit and push. Confirm your GitHub Pages URL shows the updated dashboard.
+5. Submit your live GitHub Pages URL on the **GitHub Starter Tutorial**
+   assignment in Canvas.
 
 ## Checklist
-- [ ] I picked a project path.
-- [ ] I opened that project's issues page.
-- [ ] I understand I should build in my own project repo.
+- [ ] I ran the Plan -> Code -> Commit loop with my AI tool.
+- [ ] My dashboard reflects my Command Center (the sections I built).
+- [ ] My GitHub Pages URL is live and shows my dashboard.
+- [ ] I submitted my Pages URL on the Canvas assignment.

--- a/docs/steps/README.md
+++ b/docs/steps/README.md
@@ -9,6 +9,6 @@ Use this index for the required setup path.
 5. [Step 5: Link Antigravity to `github-startup`](05-link-antigravity.md)
 6. [Step 6: Authorize GitHub Extension and Push](06-authorize-github-extension-and-push.md)
 7. [Step 7: Deploy `github-startup` to GitHub Pages](07-deploy-temporary-pages.md)
-8. [Step 8: Choose Your Project Path](08-choose-project-path.md)
+8. [Step 8: Build Your Command Center Dashboard](08-choose-project-path.md)
 
 Optional addendums are listed in [`docs/addendums/README.md`](../addendums/README.md).

--- a/index.html
+++ b/index.html
@@ -3,23 +3,81 @@
 <head>
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-  <title>Setup Complete - Temporary Deployment</title>
+  <title>AI+Design Studio Command Center</title>
   <link rel="stylesheet" href="style.css" />
 </head>
+<!--
+  THIS IS YOUR DASHBOARD. GitHub Pages serves this file.
+  Replace the placeholder text below with the real content from your
+  AI+Design Studio Command Center (Canvas: Project 2, Step 2).
+  KEEP OR TRIM: delete any <section> you did not build - all seven or a
+  subset is fine. Beginnings-level content is fine; this is the on-ramp,
+  not Project 5. Make it yours; do not leave it looking like a template.
+-->
 <body>
-  <main class="wrap">
-    <p class="label">GitHub Starter Tutorial</p>
-    <h1>Congratulations. You successfully completed setup.</h1>
-    <p>
-      This is a temporary file used to demonstrate the GitHub Pages deployment process.
-    </p>
-    <p>
-      In AI-assisted development, this is your smoke test: prove your repo, local workflow,
-      and deployment path are working before you start building the real project.
-    </p>
-    <p>
-      Next step: replace this page with your Personal Dashboard or Project #5 files.
-    </p>
+  <header class="site-header">
+    <p class="eyebrow">AI + Design Studio &#183; Command Center</p>
+    <h1 id="project-title">Your Project Title</h1>
+    <p class="tagline">One-line summary of what you are investigating &#8212; and your name.</p>
+  </header>
+
+  <main class="container">
+
+    <!-- Project Identity Card -->
+    <section aria-labelledby="identity-h">
+      <h2 id="identity-h">Project Identity Card</h2>
+      <p>Title, curiosity statement, short summary, audience / context, and possible final direction(s).</p>
+    </section>
+
+    <!-- Inquiry Brief -->
+    <section aria-labelledby="inquiry-h">
+      <h2 id="inquiry-h">Inquiry Brief</h2>
+      <p>Your research question, why it matters, what you need to learn, and 2&#8211;3 possible final outcomes.</p>
+    </section>
+
+    <!-- Source Starter List -->
+    <section aria-labelledby="sources-h">
+      <h2 id="sources-h">Source Starter List</h2>
+      <ul>
+        <li>Source 1 &#8212; title, creator, link, type, why it matters</li>
+        <li>Source 2 &#8212; title, creator, link, type, why it matters</li>
+        <li>Source 3 &#8212; optional</li>
+      </ul>
+    </section>
+
+    <!-- Project Brief / Weekly Roadmap -->
+    <section aria-labelledby="roadmap-h">
+      <h2 id="roadmap-h">Project Brief / Weekly Roadmap</h2>
+      <p>Weeks 5&#8211;11: goal, activities, tools, output, and success indicator for each week.</p>
+    </section>
+
+    <!-- Prompt Log -->
+    <section aria-labelledby="prompts-h">
+      <h2 id="prompts-h">Prompt Log</h2>
+      <p>Each entry: the prompt used, model / tool, output summary, and what changed afterward.</p>
+    </section>
+
+    <!-- Experiment Log -->
+    <section aria-labelledby="experiments-h">
+      <h2 id="experiments-h">Experiment Log</h2>
+      <p>Each experiment: what you tried, notes, what worked, what failed, and the next step.</p>
+    </section>
+
+    <!-- Links / Workspace Board -->
+    <section aria-labelledby="links-h">
+      <h2 id="links-h">Links / Workspace Board</h2>
+      <ul>
+        <li>Milanote / Notion / Figma board</li>
+        <li>AI tools used</li>
+        <li>Repo / site link</li>
+        <li>Working files (Figma, code, assets)</li>
+      </ul>
+    </section>
+
   </main>
+
+  <footer class="site-footer">
+    <p>DESN 374 &#183; Command Center &#183; built with the Interview &#8594; Brainstorm &#8594; Plan &#8594; Code &#8594; Commit workflow</p>
+  </footer>
 </body>
 </html>

--- a/style.css
+++ b/style.css
@@ -17,21 +17,16 @@ body {
   font-family: "Segoe UI", Tahoma, sans-serif;
   background: linear-gradient(180deg, #eef3fb 0%, var(--bg) 100%);
   color: var(--text);
-  display: grid;
-  place-items: center;
-  padding: 1.5rem;
+  line-height: 1.6;
 }
 
-.wrap {
-  width: min(780px, 100%);
-  background: var(--surface);
-  border: 1px solid var(--border);
-  border-radius: 14px;
-  padding: 2rem;
-  box-shadow: 0 8px 30px rgba(15, 23, 42, 0.08);
+.site-header {
+  width: min(880px, 100%);
+  margin: 0 auto;
+  padding: 3rem 1.5rem 1.5rem;
 }
 
-.label {
+.eyebrow {
   margin: 0 0 0.5rem;
   font-size: 0.85rem;
   letter-spacing: 0.06em;
@@ -40,23 +35,83 @@ body {
   font-weight: 700;
 }
 
-h1 {
-  margin: 0 0 1rem;
+.site-header h1 {
+  margin: 0 0 0.5rem;
+  font-size: 2rem;
   line-height: 1.2;
 }
 
-p {
-  margin: 0 0 1rem;
+.tagline {
+  margin: 0;
   color: var(--muted);
-  line-height: 1.6;
+}
+
+.container {
+  width: min(880px, 100%);
+  margin: 0 auto;
+  padding: 0 1.5rem 2rem;
+  display: grid;
+  gap: 1.25rem;
+}
+
+section {
+  background: var(--surface);
+  border: 1px solid var(--border);
+  border-radius: 14px;
+  padding: 1.5rem 1.75rem;
+  box-shadow: 0 8px 30px rgba(15, 23, 42, 0.06);
+}
+
+section h2 {
+  margin: 0 0 0.75rem;
+  font-size: 1.15rem;
+  color: var(--text);
+  border-bottom: 2px solid var(--border);
+  padding-bottom: 0.5rem;
+}
+
+section p {
+  margin: 0;
+  color: var(--muted);
+}
+
+section ul {
+  margin: 0;
+  padding-left: 1.25rem;
+  color: var(--muted);
+}
+
+section li {
+  margin-bottom: 0.4rem;
+}
+
+.site-footer {
+  width: min(880px, 100%);
+  margin: 0 auto;
+  padding: 1.5rem;
+  text-align: center;
+}
+
+.site-footer p {
+  margin: 0;
+  font-size: 0.85rem;
+  color: var(--muted);
+}
+
+a {
+  color: var(--accent);
 }
 
 @media (max-width: 640px) {
-  .wrap {
-    padding: 1.25rem;
+  .site-header {
+    padding: 2rem 1.25rem 1rem;
   }
 
-  h1 {
-    font-size: 1.4rem;
+  .site-header h1 {
+    font-size: 1.5rem;
+  }
+
+  section {
+    padding: 1.25rem;
   }
 }


### PR DESCRIPTION
Single-path Command Center dashboard. Replaces the two-track (Personal vs Research Dashboard) ending. index.html scaffolds the 7 Command Center sections (semantic, a11y, keep-or-trim); style.css clean dashboard layout; Step 08 retargeted to the build loop + Canvas submit; Step 07 handoff fixed; README / steps index / progress-tracker reframed to the 4 capability outcomes; no stale two-track refs. Steps 01-07, addenda, and the issue workflow unchanged. Pairs with the Week 8 Canvas walkthrough page and the github-starter-tutorial assignment.